### PR TITLE
Update README.md with environment variable setup and pytest.ini instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,20 @@ pip install -r automation-home-work/requirements.txt
 
 ## 🔧 Environment Variables
 
-To get API_ACCESS_KEY, sign up for a free API key at [ipstack.com](https://ipstack.com/signup/free).
+### Create a pytest.ini file in the automation-home-work/test_scripts folder.
+```
+[pytest]
 
-Add these before running tests:
+env =
+    ; UI General
+    DEFAULT_URL = https://m.twitch.tv/
 
-```bash
-# UI (Twitch)
-export DEFAULT_URL="https://www.twitch.tv"
-
-# API (IPstack)
-export API_URL="https://api.ipstack.com"
-export API_ACCESS_KEY="YOUR_IPSTACK_API_KEY"
+    ; API General
+    API_URL = http://api.ipstack.com
+    API_ACCESS_KEY = API_ACCESS_KEY
 ```
 
-On Windows (PowerShell):
-
-```powershell
-$env:DEFAULT_URL="https://www.twitch.tv"
-$env:API_URL="https://api.ipstack.com"
-$env:API_ACCESS_KEY="YOUR_IPSTACK_API_KEY"
-```
+### To get API_ACCESS_KEY, sign up for a free API key at [ipstack.com](https://ipstack.com/signup/free).
 
 ## ▶ How to Run Tests
 


### PR DESCRIPTION
This pull request updates the environment variable configuration instructions in the `README.md` to use a `pytest.ini` file for setting environment variables, streamlining the setup process for running tests.

**Testing environment setup:**

* Replaced manual export instructions for environment variables with guidance to create a `pytest.ini` file in the `automation-home-work/test_scripts` folder, specifying the required variables for both UI and API testing.

* Clarified that the API access key can be obtained by signing up at [ipstack.com](https://ipstack.com/signup/free).