### PR TITLE
Add pytest hook to capture screenshots on test failures in conftest.py

### DIFF
--- a/test_scripts/regression/ui_tests/conftest.py
+++ b/test_scripts/regression/ui_tests/conftest.py
@@ -1,0 +1,39 @@
+# test_scripts/regression/ui_tests/conftest.py
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+from pytest_html import extras
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
+    """Hook to take a screenshot on test failure and attach it to the pytest-html report."""
+    outcome = yield
+    rep = outcome.get_result()
+
+    if rep.when != "call" or not rep.failed:
+        return
+
+    ui = item.funcargs.get("ui")
+    driver = getattr(ui, "driver", None) if ui else None
+    if driver is None:
+        return
+
+    screenshots_dir = Path("artifacts") / "screenshots"
+    screenshots_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    filename = f"{item.name}-{ts}.png"
+    filepath = screenshots_dir / filename
+
+    # take a screenshot and save the file
+    png_bytes = driver.get_screenshot_as_png()
+    filepath.write_bytes(png_bytes)
+
+    # attach to pytest-html (self-contained-html inlines the image)
+    extra = getattr(rep, "extra", [])
+    extra.append(extras.image(png_bytes, mime_type="image/png"))
+    rep.extra = extra


### PR DESCRIPTION
## Description

This pull request adds an automated screenshot capture feature for UI test failures in the regression test suite. Now, when a UI test fails, a screenshot will be saved and attached to the pytest-html report, making debugging easier.

UI test failure reporting improvements:

* Added a pytest hook (`pytest_runtest_makereport`) in `test_scripts/regression/ui_tests/conftest.py` that captures a screenshot on test failure, saves it to the `artifacts/screenshots` directory, and attaches it to the pytest-html report for easier debugging.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

Fixes #
```
