### PR TITLE
Enhance screenshot handling in pytest: encode screenshots in base64 and update upload path in CI

### DIFF
--- a/.github/workflows/run_and_post.yml
+++ b/.github/workflows/run_and_post.yml
@@ -92,9 +92,11 @@ jobs:
           pytest -q test_scripts/regression/ui_tests --maxfail=1 --disable-warnings \
             --html=reports/ui-report.html --self-contained-html
 
-      - name: Upload UI report
+      - name: Upload UI report & screenshots
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ui-pytest-report
-          path: reports/
+          path: |
+            reports/
+            artifacts/screenshots/

--- a/test_scripts/regression/ui_tests/conftest.py
+++ b/test_scripts/regression/ui_tests/conftest.py
@@ -1,6 +1,7 @@
 # test_scripts/regression/ui_tests/conftest.py
 from __future__ import annotations
 
+import base64
 import datetime as dt
 from pathlib import Path
 
@@ -10,10 +11,11 @@ from pytest_html import extras
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
-    """Hook to take a screenshot on test failure and attach it to the pytest-html report."""
+    """Capture screenshot on test failure and attach to an HTML report."""
     outcome = yield
     rep = outcome.get_result()
 
+    # only on failure during test execution (when == 'call')
     if rep.when != "call" or not rep.failed:
         return
 
@@ -29,11 +31,10 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
     filename = f"{item.name}-{ts}.png"
     filepath = screenshots_dir / filename
 
-    # take a screenshot and save the file
     png_bytes = driver.get_screenshot_as_png()
     filepath.write_bytes(png_bytes)
 
-    # attach to pytest-html (self-contained-html inlines the image)
+    png_b64 = base64.b64encode(png_bytes).decode("ascii")
     extra = getattr(rep, "extra", [])
-    extra.append(extras.image(png_bytes, mime_type="image/png"))
+    extra.append(extras.image(png_b64, mime_type="image/png"))
     rep.extra = extra


### PR DESCRIPTION
## Description

This pull request improves the UI test workflow by enhancing screenshot handling for failed tests and ensuring screenshots are uploaded as artifacts. The main changes focus on capturing screenshots in a format compatible with the HTML report and updating the CI workflow to include these screenshots in the uploaded artifacts.

**UI test screenshot handling:**

* Updated the `pytest_runtest_makereport` hook in `conftest.py` to encode screenshots as base64 before attaching them to the HTML report, ensuring compatibility with self-contained HTML reports. [[1]](diffhunk://#diff-d130847cb8a57f02015affbf3563e5cc7e860d3e3bee00c410c20e9a8589c5d3R4) [[2]](diffhunk://#diff-d130847cb8a57f02015affbf3563e5cc7e860d3e3bee00c410c20e9a8589c5d3L32-R39)
* Improved the docstring and logic in the `pytest_runtest_makereport` hook to clarify that screenshots are only captured on test failures during the call phase.

**CI workflow improvements:**

* Modified `.github/workflows/run_and_post.yml` to upload both the UI test report and screenshots as artifacts, making them available after workflow runs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

Fixes #
```
